### PR TITLE
fix: harden action runtime logging and supply-chain/workflow pinning

### DIFF
--- a/.github/instructions/action-pmd.instructions.md
+++ b/.github/instructions/action-pmd.instructions.md
@@ -1,0 +1,43 @@
+---
+description: "Use when editing this repository's GitHub Action files, including action.yml, entrypoint.sh, Dockerfile, README.md, and workflow integration for PMD and reviewdog."
+applyTo: "{action.yml,Dockerfile,entrypoint.sh,README.md,.github/workflows/**}"
+---
+
+# action-pmd Repository Instructions
+
+This repository provides a Docker-based GitHub Action that runs PMD on Java source code and reports findings via reviewdog.
+
+- Keep runtime behavior consistent across `action.yml`, `entrypoint.sh`, and `Dockerfile`.
+- Treat this action as PMD 7.x based. Use `pmd check` syntax, not legacy PMD 6.x CLI syntax.
+- Prefer built-in PMD rulesets under `category/java/...` when providing defaults or examples.
+
+## Input and Environment Contract
+
+- If you add, rename, or remove an input in `action.yml`, update `entrypoint.sh` to use the corresponding `INPUT_*` variable.
+- Keep default values and descriptions synchronized between `action.yml` and `README.md`.
+- Preserve current reviewdog flags and names unless the change request explicitly alters behavior.
+
+## Shell Script Rules (`entrypoint.sh`)
+
+- Keep the script POSIX `sh` compatible.
+- Keep `set -e` behavior unless the user explicitly requests a different error strategy.
+- Validate user inputs before executing PMD when practical (for example, directory existence and ruleset warnings).
+- Avoid introducing Bash-only syntax.
+
+## Dockerfile Rules
+
+- Keep the multi-stage design: PMD download/build stage and runtime stage.
+- Pin tool versions via `ARG` values and update related docs when versions change.
+- Ensure required runtime tools (`git`, `wget`, `reviewdog`, Java runtime, PMD binary) remain available.
+
+## Documentation Rules (`README.md`)
+
+- Update usage examples and migration notes whenever defaults, versions, or CLI behavior change.
+- Keep guidance aligned with PMD 7.x and category-based ruleset paths.
+- If you change inputs or defaults, update the Inputs section and examples in the same change.
+
+## Change Hygiene
+
+- Prefer small, behavior-focused edits.
+- When changing command lines, preserve quoting and safe handling of empty optional flags.
+- Do not add unrelated refactors when implementing targeted fixes.

--- a/.github/workflows/depup.yml
+++ b/.github/workflows/depup.yml
@@ -10,8 +10,8 @@ jobs:
   reviewdog:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: reviewdog/action-depup@v1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: reviewdog/action-depup@94a1aaf4e4923064019214b48a43276218af7ad5 # v1.6.4
         id: depup
         with:
           file: Dockerfile
@@ -19,7 +19,7 @@ jobs:
           repo: reviewdog/reviewdog
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           title: "chore(deps): update reviewdog to ${{ steps.depup.outputs.latest }}"
@@ -36,8 +36,8 @@ jobs:
   pmd:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: reviewdog/action-depup@v1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: reviewdog/action-depup@94a1aaf4e4923064019214b48a43276218af7ad5 # v1.6.4
         id: depup
         with:
           file: Dockerfile
@@ -45,7 +45,7 @@ jobs:
           repo: pmd/pmd
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           title: "chore(deps): update PMD to ${{ steps.depup.outputs.latest }}"

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -8,6 +8,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Build the Docker image
       run: docker build . --file Dockerfile --tag ${{ github.repository }}:$(date +%s)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,13 +14,13 @@ jobs:
     if: github.event.action != 'labeled'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       # Bump version on merging Pull Requests with specific labels.
       # (bump:major,bump:minor,bump:patch)
       - id: bumpr
         if: "!startsWith(github.ref, 'refs/tags/')"
-        uses: haya14busa/action-bumpr@v1
+        uses: haya14busa/action-bumpr@faf6f474bcb6174125cfc569f0b2e24cbf03d496 # v1.11.4
 
       # Update corresponding major and minor tag.
       # e.g. Update v1 and v1.2 when releasing v1.2.3
@@ -31,7 +31,7 @@ jobs:
 
       # Get tag name.
       - id: tag
-        uses: haya14busa/action-cond@v1
+        uses: haya14busa/action-cond@94f77f7a80cd666cb3155084e428254fea4281fd # v1.2.1
         with:
           cond: "${{ startsWith(github.ref, 'refs/tags/') }}"
           if_true: ${{ github.ref }}
@@ -51,6 +51,6 @@ jobs:
     if: github.event.action == 'labeled'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Post bumpr status comment
-        uses: haya14busa/action-bumpr@v1
+        uses: haya14busa/action-bumpr@faf6f474bcb6174125cfc569f0b2e24cbf03d496 # v1.11.4

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -9,14 +9,14 @@ jobs:
     name: runner / shellcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: haya14busa/action-cond@v1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: haya14busa/action-cond@94f77f7a80cd666cb3155084e428254fea4281fd # v1.2.1
         id: reporter
         with:
           cond: ${{ github.event_name == 'pull_request' }}
           if_true: "github-pr-review"
           if_false: "github-check"
-      - uses: reviewdog/action-shellcheck@v1
+      - uses: reviewdog/action-shellcheck@4c07458293ac342d477251099501a718ae5ef86e # v1.32.0
         with:
           github_token: ${{ secrets.github_token }}
           reporter: ${{ steps.reporter.outputs.value }}
@@ -26,14 +26,14 @@ jobs:
     name: runner / hadolint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: haya14busa/action-cond@v1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: haya14busa/action-cond@94f77f7a80cd666cb3155084e428254fea4281fd # v1.2.1
         id: reporter
         with:
           cond: ${{ github.event_name == 'pull_request' }}
           if_true: "github-pr-review"
           if_false: "github-check"
-      - uses: reviewdog/action-hadolint@v1
+      - uses: reviewdog/action-hadolint@921946a7ebaaf08ac72607bad67209f4e52b5407 # v1.50.5
         with:
           github_token: ${{ secrets.github_token }}
           reporter: ${{ steps.reporter.outputs.value }}
@@ -43,8 +43,8 @@ jobs:
     name: runner / misspell
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: reviewdog/action-misspell@v1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: reviewdog/action-misspell@d6429416b12b09b4e2768307d53bef58d172e962 # v1.27.0
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-check
@@ -55,8 +55,8 @@ jobs:
     name: runner / alex
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: reviewdog/action-alex@v1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: reviewdog/action-alex@b6673b547eeb6d430c87ef02dc3524bdf34e324d # v1.16.1
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     name: runner / pmd (github-check)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./
         with:
           github_token: ${{ secrets.github_token }}
@@ -23,7 +23,7 @@ jobs:
     name: runner / pmd (github-pr-check)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./
         with:
           github_token: ${{ secrets.github_token }}
@@ -37,7 +37,7 @@ jobs:
     name: runner / pmd (github-pr-review)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./
         with:
           github_token: ${{ secrets.github_token }}
@@ -51,7 +51,7 @@ jobs:
     name: runner / pmd 7.x with cache
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Test PMD 7.x with cache enabled
         uses: ./
         with:
@@ -66,7 +66,7 @@ jobs:
     name: runner / pmd 7.x bestpractices ruleset
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Test PMD 7.x with category/java/bestpractices.xml
         uses: ./
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage: Download and extract PMD
-FROM alpine:3.19 AS pmd-builder
+FROM alpine:3.22@sha256:310c62b5e7ca5b08167e4384c68db0fd2905dd9c7493756d356e893909057601 AS pmd-builder
 
 ARG PMD_VERSION=7.20.0
 
@@ -10,23 +10,39 @@ RUN apk add --no-cache wget unzip && \
     mv /tmp/pmd-bin-${PMD_VERSION} /pmd && \
     rm /tmp/pmd.zip
 
-# Runtime stage: Eclipse Temurin Java 21 + Reviewdog
-FROM eclipse-temurin:21-alpine
+# Build stage: Download reviewdog binary from immutable release asset
+FROM alpine:3.22@sha256:310c62b5e7ca5b08167e4384c68db0fd2905dd9c7493756d356e893909057601 AS reviewdog-builder
 
 ARG REVIEWDOG_VERSION=v0.21.0
+ARG TARGETARCH
 
-# Install git and dependencies (required for reviewdog)
 # hadolint ignore=DL3018
-RUN apk add --no-cache git wget
+RUN apk add --no-cache wget tar && \
+    set -eux; \
+    case "${TARGETARCH:-amd64}" in \
+      amd64) REVIEWDOG_ARCH="x86_64" ;; \
+      arm64) REVIEWDOG_ARCH="arm64" ;; \
+      *) echo "Unsupported architecture: ${TARGETARCH}"; exit 1 ;; \
+    esac; \
+    REVIEWDOG_VERSION_NO_V="${REVIEWDOG_VERSION#v}"; \
+    wget --progress=dot:giga -O /tmp/reviewdog.tar.gz "https://github.com/reviewdog/reviewdog/releases/download/${REVIEWDOG_VERSION}/reviewdog_${REVIEWDOG_VERSION_NO_V}_Linux_${REVIEWDOG_ARCH}.tar.gz" && \
+    tar -xzf /tmp/reviewdog.tar.gz -C /tmp reviewdog && \
+    chmod +x /tmp/reviewdog
 
-# Install reviewdog
-# hadolint ignore=DL4006,SC2086
-RUN set -ex && \
-    wget -O - --progress=dot:giga https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s -- -b /usr/local/bin/ ${REVIEWDOG_VERSION} && \
-    reviewdog --version
+# Runtime stage: Eclipse Temurin Java 21 JRE + PMD + Reviewdog
+FROM eclipse-temurin:21-jre-alpine@sha256:704db3c40204a44f471191446ddd9cda5d60dab40f0e15c6507b815ed897238b
+
+# Install runtime dependency required by reviewdog for diff/filter operations
+# hadolint ignore=DL3018
+RUN apk add --no-cache git
 
 # Copy PMD from build stage
 COPY --from=pmd-builder /pmd /pmd
+
+# Copy reviewdog binary from build stage
+COPY --from=reviewdog-builder /tmp/reviewdog /usr/local/bin/reviewdog
+
+RUN reviewdog --version
 
 # Set PMD environment variables
 ENV PMD_HOME=/pmd

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ jobs:
     name: PMD job
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Run PMD
       uses: kemsakurai/action-pmd@v0.1.0
       with:
@@ -117,7 +117,7 @@ jobs:
     name: PMD job with cache
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Run PMD
       uses: kemsakurai/action-pmd@v0.1.0
       with:
@@ -138,7 +138,7 @@ jobs:
     name: PMD job with custom ruleset
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Run PMD
       uses: kemsakurai/action-pmd@v0.1.0
       with:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -57,8 +57,14 @@ else
   echo "PMD cache is disabled (INPUT_PMD_CACHE is empty)"
 fi
 
-printenv
-ls
+# Display safe runtime information for debugging
+echo "=== Runtime Information ==="
+echo "Workspace: ${GITHUB_WORKSPACE:-not set}"
+echo "Workdir: ${INPUT_WORKDIR}"
+echo "Source path: ${INPUT_SRC_PATH}"
+echo "Ruleset path: ${INPUT_RULESETS_PATH}"
+echo "PMD cache: ${INPUT_PMD_CACHE:-disabled}"
+echo "==========================="
 
 # Execute PMD with error handling
 echo "Running PMD analysis..."


### PR DESCRIPTION
## Summary
This PR applies the security hardening tracked in #10.

- Replaced full environment dump in `entrypoint.sh` with a safe allowlist output.
- Pinned Docker base images by digest in `Dockerfile`.
- Reworked reviewdog installation flow in `Dockerfile` to use release assets.
- Updated `.github/workflows/*` based on `reviewdog/action-template` and pinned actions to immutable SHAs where applicable.
- Updated README usage examples to match pinned checkout style.
- Added repository instruction file at `.github/instructions/action-pmd.instructions.md`.

## Related
- Closes #10
