### PR TITLE
PMD 7.25.0 への更新と entrypoint/Dockerfile 改善

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
+# syntax=docker/dockerfile:1
+
 # Build stage: Download and extract PMD
 FROM alpine:3.22@sha256:310c62b5e7ca5b08167e4384c68db0fd2905dd9c7493756d356e893909057601 AS pmd-builder
 
-ARG PMD_VERSION=7.20.0
+ARG PMD_VERSION=7.25.0
 
 # hadolint ignore=DL3018
 RUN apk add --no-cache wget unzip && \
@@ -41,8 +43,6 @@ COPY --from=pmd-builder /pmd /pmd
 
 # Copy reviewdog binary from build stage
 COPY --from=reviewdog-builder /tmp/reviewdog /usr/local/bin/reviewdog
-
-RUN reviewdog --version
 
 # Set PMD environment variables
 ENV PMD_HOME=/pmd

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is a GitHub action to run [PMD](https://github.com/pmd/pmd) check on your J
 
 **This version includes major updates and breaking changes:**
 
-- **PMD 7.20.0**: Upgraded from PMD 6.55.0 to 7.20.0
+- **PMD 7.25.0**: Updated to PMD 7.25.0
 - **Java 21**: Now using Eclipse Temurin 21 (upgraded from OpenJDK 17)
 - **Reviewdog v0.21.0**: Updated from v0.14.1
 - **Default Ruleset Change**: `category/java/bestpractices.xml` (was `rulesets/java/quickstart.xml`)
@@ -33,8 +33,14 @@ This is a GitHub action to run [PMD](https://github.com/pmd/pmd) check on your J
 | Component | Version |
 |-----------|---------|
 | Java | Eclipse Temurin 21 (LTS) |
-| PMD | 7.20.0 |
+| PMD | 7.25.0 |
 | Reviewdog | v0.21.0 |
+
+### PMD 7.25.0 Notes
+
+- PMD 7.25.0 updates ANTLR to 4.13.2.
+- If you maintain custom ANTLR-based PMD language modules, regenerate parsers/lexers with ANTLR 4.13.2.
+- Java rules were added/updated and violation locations were improved, so CI findings may differ from earlier PMD 7.x versions.
 
 ## Example
 
@@ -167,7 +173,7 @@ For comprehensive migration information, please refer to:
 
 3. **Deprecated Rules Removed**
    - Many legacy rules have been removed or replaced
-   - See [Removed Rules List](https://docs.pmd-code.org/pmd-doc-7.20.0/pmd_release_notes_pmd7.html#removed-rules)
+   - See [Removed Rules List](https://docs.pmd-code.org/pmd-doc-7.25.0/pmd_release_notes_pmd7.html#removed-rules)
 
 4. **Property Delimiter Change**
    - Old: Pipe `|` separator
@@ -178,8 +184,8 @@ For comprehensive migration information, please refer to:
 1. **Verify Current Ruleset Compatibility**
    ```bash
    # Test your current ruleset with PMD 7.x
-   docker build --build-arg PMD_VERSION=7.20.0 -t action-pmd:test .
-   docker run -v $(pwd):/workspace action-pmd:test pmd check -d /workspace/src -R category/java/bestpractices.xml
+  docker build --build-arg PMD_VERSION=7.25.0 -t action-pmd:test .
+  docker run --rm --entrypoint sh -v $(pwd):/workspace action-pmd:test -lc 'export PATH="/opt/java/openjdk/bin:/pmd/bin:$PATH" && pmd check -d /workspace/src -R category/java/bestpractices.xml --no-progress'
    ```
 
 2. **Update Workflow Configuration**
@@ -321,7 +327,7 @@ Error: Rule 'SomeRuleName' not found
 ```
 
 **Solution:**
-The rule may have been removed in PMD 7.x. Check the [removed rules list](https://docs.pmd-code.org/pmd-doc-7.20.0/pmd_release_notes_pmd7.html#removed-rules) and find alternatives.
+The rule may have been removed in PMD 7.x. Check the [removed rules list](https://docs.pmd-code.org/pmd-doc-7.25.0/pmd_release_notes_pmd7.html#removed-rules) and find alternatives.
 
 #### Error: "Permission denied" (Cache)
 
@@ -358,14 +364,14 @@ You can build the Docker image with custom versions of PMD or Reviewdog:
 
 ```bash
 # Build with specific PMD version
-docker build --build-arg PMD_VERSION=7.18.0 -t action-pmd:custom .
+docker build --build-arg PMD_VERSION=7.25.0 -t action-pmd:custom .
 
 # Build with specific Reviewdog version
 docker build --build-arg REVIEWDOG_VERSION=v0.20.0 -t action-pmd:custom .
 
 # Build with both custom versions
 docker build \
-  --build-arg PMD_VERSION=7.18.0 \
+  --build-arg PMD_VERSION=7.25.0 \
   --build-arg REVIEWDOG_VERSION=v0.20.0 \
   -t action-pmd:custom .
 ```

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,79 +1,165 @@
 #!/bin/sh
+# Run PMD and report findings through reviewdog in GitHub Actions.
+
 set -e
 
-if [ -n "${GITHUB_WORKSPACE}" ] ; then
-  cd "${GITHUB_WORKSPACE}/${INPUT_WORKDIR}" || exit
-  git config --global --add safe.directory "${GITHUB_WORKSPACE}" || exit 1
-fi
+info() {
+  printf '%s\n' "$*"
+}
 
-export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
+warn() {
+  printf 'Warning: %s\n' "$*" >&2
+}
 
-# Display version information for debugging
-echo "=== Environment Information ==="
-java -version
-pmd --version
-echo "Reviewdog location: $(which reviewdog || echo 'not found in PATH')"
-reviewdog --version || echo "Warning: reviewdog not executable"
-echo "PATH: $PATH"
-echo "==============================="
+err() {
+  printf 'Error: %s\n' "$*" >&2
+}
 
-# Validate source directory exists
-if [ ! -d "${INPUT_SRC_PATH}" ]; then
-  echo "Error: Source directory '${INPUT_SRC_PATH}' not found."
-  echo "Please verify the 'src_path' input parameter."
-  exit 1
-fi
+validate_required_inputs() {
+  if [ -z "${INPUT_SRC_PATH:-}" ]; then
+    err "'src_path' input is empty."
+    return 1
+  fi
 
-# Validate ruleset (if it's a file path)
-if [ -f "${INPUT_RULESETS_PATH}" ]; then
-  echo "Using custom ruleset: ${INPUT_RULESETS_PATH}"
-elif echo "${INPUT_RULESETS_PATH}" | grep -q "^category/"; then
-  echo "Using built-in ruleset: ${INPUT_RULESETS_PATH}"
-elif echo "${INPUT_RULESETS_PATH}" | grep -q "^rulesets/"; then
-  echo "Warning: You are using legacy ruleset path '${INPUT_RULESETS_PATH}'."
-  echo "PMD 7.x requires category-based paths like 'category/java/bestpractices.xml'."
-  echo "See migration guide: https://docs.pmd-code.org/latest/pmd_userdocs_migrating_to_pmd7.html"
-  echo "Attempting to continue with provided path..."
-fi
+  if [ -z "${INPUT_RULESETS_PATH:-}" ]; then
+    err "'rulesets_path' input is empty."
+    return 1
+  fi
 
-# Setup PMD cache if specified
-CACHE_OPT=""
-if [ -n "${INPUT_PMD_CACHE}" ]; then
-  echo "PMD cache enabled: ${INPUT_PMD_CACHE}"
-  # PMD cache requires a file path, not a directory
-  # Create parent directory if it doesn't exist
-  CACHE_DIR=$(dirname "${INPUT_PMD_CACHE}")
-  mkdir -p "${CACHE_DIR}" || {
-    echo "Warning: Failed to create cache directory. Continuing without cache."
-  }
+  if [ -z "${INPUT_LEVEL:-}" ]; then
+    err "'level' input is empty."
+    return 1
+  fi
+
+  if [ -z "${INPUT_FILTER_MODE:-}" ]; then
+    err "'filter_mode' input is empty."
+    return 1
+  fi
+
+  if [ -z "${INPUT_FAIL_LEVEL:-}" ]; then
+    err "'fail_level' input is empty."
+    return 1
+  fi
+}
+
+setup_workspace() {
+  if [ -n "${GITHUB_WORKSPACE:-}" ]; then
+    if ! cd "${GITHUB_WORKSPACE}/${INPUT_WORKDIR}"; then
+      err "Unable to cd to workdir '${GITHUB_WORKSPACE}/${INPUT_WORKDIR}'."
+      return 1
+    fi
+
+    if ! git config --global --add safe.directory "${GITHUB_WORKSPACE}"; then
+      err "Failed to mark '${GITHUB_WORKSPACE}' as a safe git directory."
+      return 1
+    fi
+  fi
+}
+
+print_environment_info() {
+  info '=== Environment Information ==='
+  java -version
+  pmd --version
+
+  if command -v reviewdog >/dev/null 2>&1; then
+    info "Reviewdog location: $(command -v reviewdog)"
+    reviewdog --version
+  else
+    warn 'reviewdog not found in PATH'
+  fi
+
+  info "PATH: ${PATH}"
+  info '==============================='
+}
+
+validate_paths() {
+  if [ ! -d "${INPUT_SRC_PATH}" ]; then
+    err "Source directory '${INPUT_SRC_PATH}' not found."
+    err "Please verify the 'src_path' input parameter."
+    return 1
+  fi
+
+  if [ -f "${INPUT_RULESETS_PATH}" ]; then
+    info "Using custom ruleset: ${INPUT_RULESETS_PATH}"
+    return 0
+  fi
+
+  case "${INPUT_RULESETS_PATH}" in
+    category/*)
+      info "Using built-in ruleset: ${INPUT_RULESETS_PATH}"
+      ;;
+    rulesets/*)
+      warn "You are using legacy ruleset path '${INPUT_RULESETS_PATH}'."
+      warn "PMD 7.x requires paths like 'category/java/bestpractices.xml'."
+      warn 'See migration guide: https://docs.pmd-code.org/latest/pmd_userdocs_migrating_to_pmd7.html'
+      warn 'Attempting to continue with provided path.'
+      ;;
+    *)
+      warn "Ruleset path '${INPUT_RULESETS_PATH}' is neither an existing file nor category/rulesets prefix."
+      ;;
+  esac
+}
+
+setup_cache() {
+  CACHE_OPT=''
+
+  if [ -z "${INPUT_PMD_CACHE:-}" ]; then
+    info 'PMD cache is disabled (INPUT_PMD_CACHE is empty)'
+    return 0
+  fi
+
+  info "PMD cache enabled: ${INPUT_PMD_CACHE}"
+  CACHE_DIR="$(dirname "${INPUT_PMD_CACHE}")"
+
+  if ! mkdir -p "${CACHE_DIR}"; then
+    warn 'Failed to create cache directory. Continuing without cache.'
+    return 0
+  fi
+
   if [ -d "${CACHE_DIR}" ]; then
     chmod 777 "${CACHE_DIR}" 2>/dev/null || true
     CACHE_OPT="--cache ${INPUT_PMD_CACHE}"
-    echo "✓ PMD cache file will be created at ${INPUT_PMD_CACHE}"
+    info "PMD cache file will be created at ${INPUT_PMD_CACHE}"
   else
-    echo "✗ PMD cache directory creation failed"
+    warn 'PMD cache directory creation failed. Continuing without cache.'
   fi
-else
-  echo "PMD cache is disabled (INPUT_PMD_CACHE is empty)"
-fi
+}
 
-# Display safe runtime information for debugging
-echo "=== Runtime Information ==="
-echo "Workspace: ${GITHUB_WORKSPACE:-not set}"
-echo "Workdir: ${INPUT_WORKDIR}"
-echo "Source path: ${INPUT_SRC_PATH}"
-echo "Ruleset path: ${INPUT_RULESETS_PATH}"
-echo "PMD cache: ${INPUT_PMD_CACHE:-disabled}"
-echo "==========================="
+print_runtime_info() {
+  info '=== Runtime Information ==='
+  info "Workspace: ${GITHUB_WORKSPACE:-not set}"
+  info "Workdir: ${INPUT_WORKDIR}"
+  info "Source path: ${INPUT_SRC_PATH}"
+  info "Ruleset path: ${INPUT_RULESETS_PATH}"
+  info "PMD cache: ${INPUT_PMD_CACHE:-disabled}"
+  info '==========================='
+}
 
-# Execute PMD with error handling
-echo "Running PMD analysis..."
-# shellcheck disable=SC2086
-pmd check -d "${INPUT_SRC_PATH}" -R "${INPUT_RULESETS_PATH}" ${CACHE_OPT} -f emacs --no-progress \
-  | reviewdog -efm="%f:%l: %m" \
-      -name="${INPUT_TOOL_NAME}" \
-      -reporter="${INPUT_REPORTER:-github-pr-check}" \
-      -filter-mode="${INPUT_FILTER_MODE}" \
-      -fail-level="${INPUT_FAIL_LEVEL}" \
-      -level="${INPUT_LEVEL}" \
-      ${INPUT_REVIEWDOG_FLAGS}
+run_analysis() {
+  info 'Running PMD analysis...'
+
+  # INPUT_REVIEWDOG_FLAGS is intentionally word-split to support multiple flags.
+  # shellcheck disable=SC2086
+  pmd check -d "${INPUT_SRC_PATH}" -R "${INPUT_RULESETS_PATH}" ${CACHE_OPT} -f emacs --no-progress \
+    | reviewdog -efm='%f:%l: %m' \
+        -name="${INPUT_TOOL_NAME}" \
+        -reporter="${INPUT_REPORTER:-github-pr-check}" \
+        -filter-mode="${INPUT_FILTER_MODE}" \
+        -fail-level="${INPUT_FAIL_LEVEL}" \
+        -level="${INPUT_LEVEL}" \
+        ${INPUT_REVIEWDOG_FLAGS}
+}
+
+main() {
+  export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN:-}"
+
+  validate_required_inputs
+  setup_workspace
+  print_environment_info
+  validate_paths
+  setup_cache
+  print_runtime_info
+  run_analysis
+}
+
+main "$@"


### PR DESCRIPTION
## 概要
Issue #13 の対応として、PMD 7.25.0 への更新と関連改善を実施しました。

## 変更内容
- `Dockerfile`
  - PMD を `7.25.0` へ更新
  - `# syntax=docker/dockerfile:1` を追加
  - 不要な `RUN reviewdog --version` レイヤを削除
- `entrypoint.sh`
  - 関数分割と `main` 導入
  - 必須入力バリデーション追加
  - エラー/警告出力を stderr に整理
  - ruleset 判定を `case` に整理
- `README.md`
  - PMD バージョン表記や参照リンクを更新（7.25.0）

## 動作確認
- Docker image build 成功
- `entrypoint.sh` の正常系・異常系（必須入力不足、src_path不正、legacy ruleset指定）を確認
- PMD 7.20.0 と 7.25.0 の testdata に対する出力差分比較（差分なし）

Closes #13